### PR TITLE
fix(threat-watch): add support for Network 10.x traffic-flows API

### DIFF
--- a/tools/threat_watch/scheduler.py
+++ b/tools/threat_watch/scheduler.py
@@ -43,13 +43,113 @@ def get_last_refresh() -> datetime:
 
 def parse_unifi_event(event: dict) -> dict:
     """
-    Parse a raw UniFi IPS event into our database format
+    Parse a raw UniFi IPS event into our database format.
+
+    Supports both:
+    - Legacy format (stat/ips/event endpoint, pre-Network 10.x)
+    - v2 format (traffic-flows endpoint, Network 10.x+)
 
     Args:
         event: Raw event dictionary from UniFi API
 
     Returns:
         Dictionary with fields mapped to our ThreatEvent model
+    """
+    # Detect v2 format by presence of 'ips' object
+    if 'ips' in event:
+        return _parse_v2_traffic_flow(event)
+    else:
+        return _parse_legacy_ips_event(event)
+
+
+def _parse_v2_traffic_flow(event: dict) -> dict:
+    """
+    Parse a v2 traffic-flows event (Network 10.x+) into our database format.
+
+    The v2 format has IPS data nested in an 'ips' object and source/destination
+    info in 'source' and 'destination' objects.
+    """
+    # Parse timestamp - v2 uses 'time' in milliseconds
+    timestamp = None
+    if 'time' in event:
+        try:
+            ts_ms = event['time']
+            timestamp = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        except (ValueError, TypeError):
+            pass
+    if not timestamp:
+        timestamp = datetime.now(timezone.utc)
+
+    # Extract IPS data
+    ips = event.get('ips', {})
+    source = event.get('source', {})
+    destination = event.get('destination', {})
+
+    # Map risk level to severity (v2 uses 'risk': low/medium/high)
+    risk = event.get('risk', 'low')
+    severity_map = {'high': 1, 'medium': 2, 'low': 3}
+    severity = severity_map.get(risk, 3)
+
+    # Map action (v2 uses 'action': allowed/blocked)
+    action = event.get('action', 'alert')
+    if action == 'blocked':
+        action = 'block'
+    elif action == 'allowed':
+        action = 'alert'
+
+    # Build signature message from IPS data
+    signature = ips.get('signature', '')
+    message = ips.get('advanced_information', '') or signature
+
+    return {
+        'unifi_event_id': event.get('id') or str(event.get('time', '')),
+        'flow_id': ips.get('session_id'),
+        'timestamp': timestamp,
+
+        # Alert info from ips object
+        'signature': signature,
+        'signature_id': ips.get('signature_id'),
+        'severity': severity,
+        'category': ips.get('category_name'),
+        'action': action,
+        'message': message,
+
+        # Network - from source/destination objects
+        'src_ip': source.get('ip'),
+        'src_port': source.get('port'),
+        'src_mac': source.get('mac'),
+        'dest_ip': destination.get('ip'),
+        'dest_port': destination.get('port'),
+        'dest_mac': destination.get('mac'),
+        'protocol': event.get('protocol'),
+        'app_protocol': event.get('service'),
+        'interface': None,  # Not available in v2
+
+        # Geo - v2 doesn't include geolocation data
+        'src_country': None,
+        'src_city': None,
+        'src_latitude': None,
+        'src_longitude': None,
+        'src_asn': None,
+        'src_org': None,
+
+        'dest_country': None,
+        'dest_city': None,
+        'dest_latitude': None,
+        'dest_longitude': None,
+        'dest_asn': None,
+        'dest_org': None,
+
+        # Meta
+        'site_id': None,  # Not directly available in v2
+        'archived': False,
+        'raw_data': json.dumps(event)
+    }
+
+
+def _parse_legacy_ips_event(event: dict) -> dict:
+    """
+    Parse a legacy stat/ips/event response (pre-Network 10.x) into our database format.
     """
     # Parse timestamp - UniFi uses milliseconds
     timestamp = None


### PR DESCRIPTION
## Summary
- Adds support for the new UniFi Network 10.x v2 traffic-flows API endpoint
- Maintains backward compatibility with older firmware using legacy stat/ips/event
- Updates debug endpoint to test both APIs and report which one is working

## Background
UniFi Network 10.x moved IPS events from `stat/ips/event` to a new v2 endpoint at `/proxy/network/v2/api/site/{site}/traffic-flows`. This was causing Threat Watch to show no events on Network 10.x installations.

## Changes
- `shared/unifi_client.py`: Add `get_traffic_flows()` method, update `get_ips_events()` to try v2 first
- `tools/threat_watch/scheduler.py`: Add v2 event parser for new response format
- `tools/threat_watch/routers/events.py`: Update debug endpoint to test both APIs

## Test plan
- [x] Tested v2 API against UCG-Fiber running Network 10.0.162
- [x] Verified event parsing produces correct database format
- [ ] Full Docker deployment test

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)