### PR TITLE
docs: remove product selector link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ Real-time network monitoring dashboard.
 
 <img width="1895" height="957" alt="image" src="https://github.com/user-attachments/assets/ca6f0df5-8657-4c2a-ad16-8807aa21bcac" />
 
-### UI Product Selector *(External)*
-Build the perfect UniFi network at [uiproductselector.com](https://uiproductselector.com)
-
 ---
 
 ## Quick Start


### PR DESCRIPTION
Removes the reference to UI Product Selector, a service that has been sunset, from the README.

> The UI Product Selector has been retired. It was a fun ride building this tool and helping folks put together their perfect network setups.